### PR TITLE
ci: don't break on low cov

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,11 +74,10 @@ tests = ["tests", "*/tests"]
 
 [tool.coverage.run]
 branch = true
-source = ["py21cmemu", "tests"]
+source = ["py21cmemu"]
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 100
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Here I am attempting to fix the breaking coverage uploads. The codecov action will still fail (because we're under 100% coverage right now), but at least we'll be able to check out the coverage on codecov.