### PR TITLE
feat: better separation of responsibility into small classes

### DIFF
--- a/src/py21cmemu/config.py
+++ b/src/py21cmemu/config.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
+from typing import Generator
 
 import toml
 from appdirs import AppDirs
@@ -16,7 +18,7 @@ APPDIR = AppDirs("py21cmEMU")
 class Config:
     """Class that handles the configuration file."""
 
-    def __init__(self, config_file=None):
+    def __init__(self, config_file: str | Path | None = None) -> None:
         if config_file is None:
             config_file = Path(APPDIR.user_config_dir) / "config.toml"
         else:
@@ -37,62 +39,51 @@ class Config:
         if not self.data_path.exists():
             self.data_path.mkdir(parents=True, exist_ok=True)
 
-    # def add_emulator(self, emu: str):
-    #     """Add a new emulator version to the config."""
-    #     self["emu-versions"] += (emu,)
-    #     self.config_file.write_text(toml.dumps(self.config))
-
     @property
-    def emu_path(self):
+    def emu_path(self) -> Path:
         """Get the path to the emulator data."""
         return Path(self["data-path"]) / "21cmEMU" / "21cmEMU"
 
-    # def get_emulator(self, emu: str):
-    #     """Get the path to the emulator data."""
-    #     if emu not in self["emu-versions"]:
-    #         raise ValueError(f"Emulator {emu} not found in config file.")
-    #     return Path(self["data-path"]) / emu
-
     @property
-    def data_path(self):
+    def data_path(self) -> Path:
         """Get the path to the data directory."""
         return Path(self["data-path"])
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         """Get a value from the config file."""
         return self.config[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any):
         """Set a value in the config file."""
         self.config[key] = value
         self.config_file.write_text(toml.dumps(self.config))
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str) -> None:
         """Delete a value from the config file."""
         del self.config[key]
         self.config_file.write_text(toml.dumps(self.config))
 
-    def __contains__(self, key):
+    def __contains__(self, key: str) -> bool:
         """Check if a key is in the config file."""
         return key in self.config
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Get the string representation of the config file."""
         return repr(self.config)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Get the string representation of the config file."""
         return str(self.config)
 
-    def keys(self):
+    def keys(self) -> Generator[str, None, None]:
         """Get the keys in the config file."""
         return self.config.keys()
 
-    def values(self):
+    def values(self) -> Generator[Any, None, None]:
         """Get the values in the config file."""
         return self.config.values()
 
-    def items(self):
+    def items(self) -> Generator[tuple[str, Any], None, None]:
         """Get the items in the config file."""
         return self.config.items()
 

--- a/src/py21cmemu/emulator.py
+++ b/src/py21cmemu/emulator.py
@@ -10,6 +10,7 @@ import tensorflow as tf
 from .config import CONFIG
 from .get_emulator import get_emu_data
 from .inputs import EmulatorInput
+from .inputs import ParamVecType
 from .output import EmulatorOutput
 from .output import RawEmulatorOutput
 from .properties import emulator_properties
@@ -41,7 +42,7 @@ class Emulator:
         return getattr(self.properties, name)
 
     def predict(
-        self, astro_params: np.ndarray | dict | list, verbose: bool = False
+        self, astro_params: ParamVecType, verbose: bool = False
     ) -> tuple[np.ndarray, EmulatorOutput, dict[str, np.ndarray]]:
         r"""Call the emulator, evaluate it at the given parameters, restore dimensions.
 
@@ -72,7 +73,9 @@ class Emulator:
 
         return theta, emu, errors
 
-    def get_errors(self, emu: EmulatorOutput, theta: np.ndarray | None = None) -> dict:
+    def get_errors(
+        self, emu: EmulatorOutput, theta: np.ndarray | None = None
+    ) -> dict[str, np.ndarray]:
         """Calculate the emulator error on its outputs.
 
         Parameters

--- a/src/py21cmemu/emulator.py
+++ b/src/py21cmemu/emulator.py
@@ -2,54 +2,20 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+from typing import Any
 
 import numpy as np
 import tensorflow as tf
 
 from .config import CONFIG
 from .get_emulator import get_emu_data
+from .inputs import EmulatorInput
 from .output import EmulatorOutput
+from .output import RawEmulatorOutput
+from .properties import emulator_properties
 
 
 log = logging.getLogger(__name__)
-
-USER_PARAMS = {
-    "BOX_LEN": 250,
-    "DIM": 512,
-    "HII_DIM": 128,
-    "USE_FFTW_WISDOM": True,
-    "HMF": 1,
-    "USE_RELATIVE_VELOCITIES": False,
-    "POWER_SPECTRUM": 0,
-    "N_THREADS": 1,
-    "PERTURB_ON_HIGH_RES": False,
-    "NO_RNG": False,
-    "USE_INTERPOLATION_TABLES": True,
-    "FAST_FCOLL_TABLES": False,
-    "USE_2LPT": True,
-    "MINIMIZE_MEMORY": False,
-}
-
-COSMO_PARAMS = {
-    "SIGMA_8": 0.82,
-    "hlittle": 0.6774,
-    "OMm": 0.3075,
-    "OMb": 0.0486,
-    "POWER_INDEX": 0.97,
-}
-
-FLAG_OPTIONS = {
-    "USE_HALO_FIELD": False,
-    "USE_MINI_HALOS": False,
-    "USE_MASS_DEPENDENT_ZETA": True,
-    "SUBCELL_RSD": True,
-    "INHOMO_RECO": True,
-    "USE_TS_FLUCT": True,
-    "M_MIN_in_Mass": False,
-    "PHOTON_CONS": True,
-    "FIX_VCB_AVG": False,
-}
 
 
 class Emulator:
@@ -57,65 +23,26 @@ class Emulator:
 
     Parameters
     ----------
-    io_options : dict, optional
-        Dict containing 'store' and 'cache_dir' keys with the keys of summaries to
-        store and folder path where to store them, respectively. This must be
-        provided only if you want to save the emulator output at each evaluation.
-    emu_only : bool, optional
-        If set to True, skips the 21cmFAST calls to calculate tau_e and UV LFs.
-        Set to True only if you don't need tau_e and UV LFs in your output.
     version : str, optional
         Emulator version to use/download, default is 'latest'.
-
     """
 
-    def __init__(
-        self,
-        io_options: dict | None = None,
-        version: str = "latest",
-    ):
+    def __init__(self, version: str = "latest"):
         get_emu_data(version=version)
 
         emu = tf.keras.models.load_model(CONFIG.emu_path, compile=False)
 
         self.model = emu
-        self.io_options = io_options
+        self.inputs = EmulatorInput()
+        self.properties = emulator_properties
 
-        here = Path(__file__).parent
-        all_emulator_numbers = np.load(here / "emulator_constants.npz")
+    def __getattr__(self, name: str) -> Any:
+        """Allow access to emulator properties directly from the emulator object."""
+        return getattr(self.properties, name)
 
-        self.flag_options = FLAG_OPTIONS
-        self.user_params = USER_PARAMS
-        self.cosmo_params = COSMO_PARAMS
-
-        self.zs = all_emulator_numbers["zs"]
-        self.limits = all_emulator_numbers["limits"]
-        self.zs_cut = self.zs[:60]
-        self.ks_cut = all_emulator_numbers["ks"][1:-3]
-        self.PS_mean = all_emulator_numbers["PS_mean"]
-        self.PS_std = all_emulator_numbers["PS_std"]
-        self.Tb_mean = all_emulator_numbers["Tb_mean"]
-        self.Tb_std = all_emulator_numbers["Tb_std"]
-        self.Ts_mean = all_emulator_numbers["Ts_mean"]
-        self.Ts_std = all_emulator_numbers["Ts_std"]
-
-        self.tau_mean = all_emulator_numbers["tau_mean"]
-        self.tau_std = all_emulator_numbers["tau_std"]
-
-        self.UVLFs_mean = all_emulator_numbers["UVLFs_mean"]
-        self.UVLFs_std = all_emulator_numbers["UVLFs_std"]
-        self.UVLFs_MUVs = np.append(
-            np.arange(-25, -15, 1.0), np.arange(-15, -4.5, 0.5)
-        )  # all_emulator_numbers['UVLFs_MUVs']
-        self.uv_lf_zs = np.array([6, 7, 8, 10])
-
-        self.PS_err = all_emulator_numbers["PS_err"]
-        self.Tb_err = all_emulator_numbers["Tb_err"]
-        self.Ts_err = all_emulator_numbers["Ts_err"]
-        self.xHI_err = all_emulator_numbers["xHI_err"]
-        self.tau_err = all_emulator_numbers["tau_err"]
-
-    def predict(self, astro_params: np.ndarray | dict | list, verbose: bool = False):
+    def predict(
+        self, astro_params: np.ndarray | dict | list, verbose: bool = False
+    ) -> tuple[np.ndarray, EmulatorOutput, dict[str, np.ndarray]]:
         r"""Call the emulator, evaluate it at the given parameters, restore dimensions.
 
         Parameters
@@ -127,113 +54,30 @@ class Emulator:
             (for batch evaluation).
         verbose : bool, optional
             If True, prints the emulator prediction.
-        emulate_LFs : bool, optional
-            Default is True, the UV LFs are emulated.
-            If False, uses 21cmFAST to calculate analytically.
-        emulate_tau : bool, optional
-            Default is True, tau is emulated.
-            If False, use 21cmFAST to calculate analytically.
+
+        Returns
+        -------
+        theta : np.ndarray
+            The normalized parameters used to evaluate the emulator.
+        emu : EmulatorOutput
+            The emulator output, with dimensions restored.
+        errors : dict
+            The mean error on the test set (i.e. independent of theta).
         """
-        astro_params, theta = self.format_theta(astro_params)
-        emu_pred = self.model.predict(theta, verbose=verbose)
+        theta = self.inputs.make_param_array(astro_params, normed=True)
+        emu = RawEmulatorOutput(self.model.predict(theta, verbose=verbose))
+        emu = emu.get_renormalized()
 
-        Tb_pred_normed = emu_pred[:, :84]  # First 84 numbers of emu prediction are Tb
-        xHI_pred = emu_pred[:, 84 : 84 * 2]  # Next 84 numbers are xHI
-        Ts_pred_normed = emu_pred[:, 2 * 84 : 84 * 3]  # Next 84 numbers are Ts
-        Ts_undefined_pred = emu_pred[
-            :, 84 * 3
-        ]  # Right after Ts is the redshift at which Ts becomes undefined
-        PS_pred_normed = emu_pred[:, 84 * 3 + 1 : 84 * 3 + 1 + 60 * 12].reshape(
-            (theta.shape[0], 60, 12)
-        )  # The 60 z x 12 k PS
-        tau_pred_normed = emu_pred[:, 84 * 3 + 1 + 60 * 12]  # tau_e is one number
-        UVLFs_pred_normed = emu_pred[
-            :, 84 * 3 + 1 + 60 * 12 + 1 :
-        ]  # Last 124 numbers are UV LFs at z = 6, 7, 8, 10.
+        errors = self.get_errors(emu, theta)
 
-        # Restore dimensions
-        PS_pred = self.PS_mean + self.PS_std * PS_pred_normed  # log10(PS[mK^2])
-        Ts_pred = self.Ts_mean + self.Ts_std * Ts_pred_normed  # log10(Ts[mK])
-        Tb_pred = self.Tb_mean + self.Tb_std * Tb_pred_normed  # Tb[mK]
-        tau_pred = self.tau_mean + self.tau_std * tau_pred_normed  # log10(tau_e)
-        UVLFs_pred = (
-            self.UVLFs_mean + self.UVLFs_std * UVLFs_pred_normed
-        )  # log10(\phi/Mpc^{-3})
+        return theta, emu, errors
 
-        UVLFs = np.zeros(
-            (UVLFs_pred.shape[0], len(self.uv_lf_zs), len(self.UVLFs_MUVs))
-        )
-        current_idx = 0
-        for i in range(len(self.uv_lf_zs)):
-            UVLFs[:, i, :] = UVLFs_pred[
-                :, current_idx : current_idx + len(self.UVLFs_MUVs)
-            ]
-            current_idx += len(self.UVLFs_MUVs)
-        # Set the xHI < z(Ts undefined) to 0
-        # For Ts, set it to NaN
-        xHI_pred_fix = np.zeros(xHI_pred.shape)
-        Ts_pred_fix = np.zeros(Ts_pred.shape)
-        for i in range(theta.shape[0]):
-            zbin = np.argmin(abs(self.zs - Ts_undefined_pred[i]))
-            if xHI_pred[i, zbin] < 1e-1:
-                xHI_pred_fix[i, zbin:] = xHI_pred[i, zbin:]
-            else:
-                xHI_pred_fix[i, :] = xHI_pred[i, :]
-            Ts_pred_fix[i, zbin:] = Ts_pred[i, zbin:]
-            Ts_pred_fix[i, :zbin] = np.nan
-        if theta.shape[0] == 1:
-            summaries = {
-                "delta": 10 ** PS_pred[0, ...],
-                "k": self.ks_cut,
-                "brightness_temp": Tb_pred[0, ...],
-                "spin_temp": 10 ** Ts_pred_fix[0, ...],
-                "tau_e": 10 ** tau_pred[0],
-                "Muv": self.UVLFs_MUVs[0, ...]
-                if len(self.UVLFs_MUVs.shape) == 3
-                else self.UVLFs_MUVs,
-                "lfunc": UVLFs,
-                "uv_lfs_redshifts": self.uv_lf_zs,
-                "ps_redshifts": self.zs_cut,
-                "redshifts": self.zs,
-                "xHI": xHI_pred_fix[0, ...],
-            }
-        else:
-            summaries = {
-                "delta": 10**PS_pred,
-                "k": self.ks_cut,
-                "brightness_temp": Tb_pred,
-                "spin_temp": 10**Ts_pred_fix,
-                "tau_e": 10**tau_pred,
-                "Muv": self.UVLFs_MUVs,
-                "lfunc": UVLFs,
-                "uv_lfs_redshifts": self.uv_lf_zs,
-                "ps_redshifts": self.zs_cut,
-                "redshifts": self.zs,
-                "xHI": xHI_pred_fix,
-            }
-        errors = self.get_errors(summaries, theta)
-        # Put the summaries and errors in one single dict
-        output = EmulatorOutput(summaries)
-        output.add_errors(errors)
-        if (
-            self.io_options is not None
-            and self.io_options["cache_dir"] is not None
-            and len(self.io_options["store"]) > 0
-        ):
-            fname = "_".join(
-                [str(np.round(astro_params[i], 5)) for i in range(len(theta))]
-            )
-            to_save = {i: output[i] for i in self.io_options["store"]}
-            np.savez(fname, to_save)
-
-        return output
-
-    def get_errors(self, summaries: dict, theta: np.ndarray | None = None) -> dict:
-        r"""Calculate the emulator error on its outputs.
+    def get_errors(self, emu: EmulatorOutput, theta: np.ndarray | None = None) -> dict:
+        """Calculate the emulator error on its outputs.
 
         Parameters
         ----------
-        summaries : dict
+        emu : dict
             Dict containing the emulator predictions, defined in Emulator.predict
         theta : dict
             Dict containing the normalized parameters, also defined in Emulator.predict
@@ -246,90 +90,9 @@ class Emulator:
         # each summary. Some errors are fractional => actual error = fractional
         # error * value
         return {
-            "delta_err": self.PS_err / 100.0 * summaries["delta"],
+            "delta_err": self.PS_err / 100.0 * emu.PS,
             "brightness_temp_err": self.Tb_err,
             "xHI_err": self.xHI_err,
             "spin_temp_err": self.Ts_err,
-            "tau_e_err": self.tau_err / 100.0 * summaries["tau_e"],
+            "tau_e_err": self.tau_err / 100.0 * emu.tau,
         }
-
-    def format_theta(self, astro_params):
-        """Format the astro_params input to be a numpy array."""
-        astro_param_keys = [
-            "F_STAR10",
-            "ALPHA_STAR",
-            "F_ESC10",
-            "ALPHA_ESC",
-            "M_TURN",
-            "t_STAR",
-            "L_X",
-            "NU_X_THRESH",
-            "X_RAY_SPEC_INDEX",
-        ]
-        is_astroparams = False
-        if isinstance(astro_params, dict):
-            theta = np.array([astro_params[key] for key in astro_param_keys])
-        elif type(astro_params) == np.ndarray:
-            if len(astro_params.shape) > 1 and astro_params.shape[0] > 1:
-                theta = np.zeros(astro_params.shape)
-                if isinstance(astro_params, dict):
-                    theta = np.array([astro_params[key] for key in astro_param_keys])
-                elif type(astro_params[0]) == np.ndarray:
-                    theta = astro_params.copy()
-                else:
-                    raise TypeError(
-                        "theta is in the wrong format. Should be AstroParams object, "
-                        "dict of astro params or nine astrophysical parameters in same "
-                        "order as astro_param_keys. It can also be an array of either "
-                        "AstroParams objects, dicts, or arrays (not mixed together)."
-                    )
-            else:
-                theta = astro_params.copy()
-        else:
-            raise TypeError(
-                "theta is in the wrong format. Should be AstroParams object, dict or "
-                "nine astrophysical parameters in same order as astro_param_keys. It "
-                "can also be an array of either AstroParams objects, dicts, or arrays "
-                "(not mixed together)."
-            )
-        if len(theta.shape) == 1:
-            theta = theta.reshape([1, -1])
-        normed = True
-        if not is_astroparams and max(theta.ravel()) <= 1 and min(theta.ravel()) >= 0:
-            return (
-                (self.undo_normalization(theta), theta)
-                if normed
-                else (np.array([astro_params]), theta)
-            )
-        normed = False  # to indicate that input params was not normalised
-        theta[:, [0, 2, 4, 6]] = np.log10(theta[:, [0, 2, 4, 6]])
-        theta[:, 7] /= 1000
-        theta -= self.limits[:, 0]
-        theta /= self.limits[:, 1] - self.limits[:, 0]
-        # Restore dimensions i.e. undo the limits
-        all_astro_params = self.undo_normalization(theta)
-
-        return all_astro_params, theta
-
-    def undo_normalization(self, theta):
-        """Undo the normalization of the parameters."""
-        theta_wdims = theta.copy()
-        theta_wdims *= self.limits[:, 1] - self.limits[:, 0]
-        theta_wdims += self.limits[:, 0]
-        theta_wdims[:, 7] *= 1000
-        all_astro_params = []
-        for i in range(theta.shape[0]):
-            all_astro_params.append(
-                {
-                    "F_STAR10": theta_wdims[i, 0],
-                    "ALPHA_STAR": theta_wdims[i, 1],
-                    "F_ESC10": theta_wdims[i, 2],
-                    "ALPHA_ESC": theta_wdims[i, 3],
-                    "M_TURN": theta_wdims[i, 4],
-                    "t_STAR": theta_wdims[i, 5],
-                    "L_X": theta_wdims[i, 6],
-                    "NU_X_THRESH": theta_wdims[i, 7],
-                    "X_RAY_SPEC_INDEX": theta_wdims[i, 8],
-                }
-            )
-        return all_astro_params

--- a/src/py21cmemu/inputs.py
+++ b/src/py21cmemu/inputs.py
@@ -1,6 +1,7 @@
 """Module containing functionality for handling emulator inputs."""
 from __future__ import annotations
 
+from typing import Dict
 from typing import Sequence
 
 import numpy as np
@@ -8,7 +9,7 @@ import numpy as np
 from .properties import emulator_properties as properties
 
 
-SingleParamVecType = dict[str, float] | np.ndarray | Sequence[float]
+SingleParamVecType = Dict[str, float] | np.ndarray | Sequence[float]
 ParamVecType = Sequence[SingleParamVecType] | SingleParamVecType
 
 

--- a/src/py21cmemu/inputs.py
+++ b/src/py21cmemu/inputs.py
@@ -1,8 +1,15 @@
 """Module containing functionality for handling emulator inputs."""
+from __future__ import annotations
+
+from typing import Sequence
 
 import numpy as np
 
 from .properties import emulator_properties as properties
+
+
+SingleParamVecType = dict[str, float] | np.ndarray | Sequence[float]
+ParamVecType = Sequence[SingleParamVecType] | SingleParamVecType
 
 
 class EmulatorInput:
@@ -20,9 +27,7 @@ class EmulatorInput:
         "X_RAY_SPEC_INDEX",
     )
 
-    def _format_single_theta_vector(
-        self, theta: list[float] | np.ndarray | dict[str, float]
-    ) -> np.ndarray:
+    def _format_single_theta_vector(self, theta: SingleParamVecType) -> np.ndarray:
         if len(theta) != len(self.astro_param_keys):
             raise ValueError(
                 "One of the parameter vectors given is not the correct length. Got "
@@ -38,7 +43,7 @@ class EmulatorInput:
 
     def make_param_array(
         self,
-        astro_params: dict[str, float] | np.ndarray | list[dict[str, float]],
+        astro_params: ParamVecType,
         normed: bool = True,
     ) -> np.ndarray:
         """Format the astro_params input to be a numpy array.
@@ -77,7 +82,7 @@ class EmulatorInput:
             return self.normalize(theta)
 
     def make_list_of_dicts(
-        self, theta: np.ndarray, normed: bool = True
+        self, theta: ParamVecType, normed: bool = True
     ) -> list[dict[str, float]]:
         """Make a list of dicts from a theta array.
 

--- a/src/py21cmemu/inputs.py
+++ b/src/py21cmemu/inputs.py
@@ -1,0 +1,140 @@
+"""Module containing functionality for handling emulator inputs."""
+
+import numpy as np
+
+from .properties import emulator_properties as properties
+
+
+class EmulatorInput:
+    """Class for handling emulator inputs."""
+
+    astro_param_keys = (
+        "F_STAR10",
+        "ALPHA_STAR",
+        "F_ESC10",
+        "ALPHA_ESC",
+        "M_TURN",
+        "t_STAR",
+        "L_X",
+        "NU_X_THRESH",
+        "X_RAY_SPEC_INDEX",
+    )
+
+    def _format_single_theta_vector(
+        self, theta: list[float] | np.ndarray | dict[str, float]
+    ) -> np.ndarray:
+        if len(theta) != len(self.astro_param_keys):
+            raise ValueError(
+                "One of the parameter vectors given is not the correct length. Got "
+                f"{len(theta)} but require {len(self.astro_param_keys)}."
+            )
+
+        if isinstance(theta, dict):
+            return np.array([float(theta[key]) for key in self.astro_param_keys])
+        elif isinstance(theta, np.ndarray):
+            return theta.astype(float)
+        elif isinstance(theta, list):
+            return np.array(theta, dtype=float)
+
+    def make_param_array(
+        self,
+        astro_params: dict[str, float] | np.ndarray | list[dict[str, float]],
+        normed: bool = True,
+    ) -> np.ndarray:
+        """Format the astro_params input to be a numpy array.
+
+        Parameters
+        ----------
+        astro_params : dict or np.ndarray
+            Input parameters to the emulator, to be reformatted as a numpy array
+            compatible with the emulator. Can be a dict of astro params or a list/array
+            of floats, in the same order as astro_param_keys. It could also be a list
+            or array of such objects, for batch evaluation (the type can be mixed).
+        normed : bool, optional
+            Whether to return the parameters normalized or not (i.e. between 0 and 1).
+        """
+        if not hasattr(astro_params, "__len__"):
+            raise TypeError(
+                "astro_params is in the wrong format. Should be a dict of astro params,"
+                " list of astro params (in same order as astro_param_keys), or an array"
+                " of astro params (in same order as astro_param_keys), OR a sequence of"
+                " such."
+            )
+
+        if not hasattr(astro_params[0], "__len__"):
+            astro_params = [astro_params]
+
+        theta = np.array(
+            [self._format_single_theta_vector(theta) for theta in astro_params]
+        )
+
+        params_normed = theta.min() >= 0 and theta.max() <= 1
+        if (params_normed and normed) or (not params_normed and not normed):
+            return theta
+        elif params_normed:
+            return self.undo_normalization(theta)
+        else:
+            return self.normalize(theta)
+
+    def make_list_of_dicts(
+        self, theta: np.ndarray, normed: bool = True
+    ) -> list[dict[str, float]]:
+        """Make a list of dicts from a theta array.
+
+        Parameters
+        ----------
+        theta : np.ndarray
+            Input parameters, in any format accepted by :func:`~make_param_array`.
+        normed : bool, optional
+            Whether to return the parameters normalized or not (i.e. between 0 and 1).
+
+        Returns
+        -------
+        list of dicts
+            List of dicts of astro params, one for each parameter set.
+        """
+        theta = self.make_param_array(theta, normed=normed)
+        return [
+            dict(zip(self.astro_param_keys, theta[i], strict=True))
+            for i in range(len(theta))
+        ]
+
+    def normalize(self, theta: np.ndarray) -> np.ndarray:
+        """Normalize the parameters.
+
+        Parameters
+        ----------
+        theta : np.ndarray
+            Input parameters, strictly in 2D array format, with shape
+            (n_batch, n_params).
+
+        Returns
+        -------
+        np.ndarray
+            Normalized parameters, with shape (n_batch, n_params).
+        """
+        theta_wdims = theta.copy()
+        theta_wdims[:, 7] /= 1000
+        theta_wdims[:, [0, 2, 4, 6]] = np.log10(theta_wdims[:, [0, 2, 4, 6]])
+        theta_wdims -= properties.limits[:, 0]
+        theta_wdims /= properties.limits[:, 1] - properties.limits[:, 0]
+        return theta_wdims
+
+    def undo_normalization(self, theta: np.ndarray) -> np.ndarray:
+        """Undo the normalization of the parameters.
+
+        Parameters
+        ----------
+        theta : np.ndarray
+            Input parameters, strictly in 2D array format, with shape
+            (n_batch, n_params).
+
+        Returns
+        -------
+        np.ndarray
+            Un-normalized parameters, with shape (n_batch, n_params).
+        """
+        theta_wdims = theta.copy()
+        theta_wdims *= properties.limits[:, 1] - properties.limits[:, 0]
+        theta_wdims += properties.limits[:, 0]
+        theta_wdims[:, 7] *= 1000

--- a/src/py21cmemu/inputs.py
+++ b/src/py21cmemu/inputs.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 
 from typing import Dict
 from typing import Sequence
+from typing import Union
 
 import numpy as np
 
 from .properties import emulator_properties as properties
 
 
-SingleParamVecType = Dict[str, float] | np.ndarray | Sequence[float]
-ParamVecType = Sequence[SingleParamVecType] | SingleParamVecType
+SingleParamVecType = Union[Dict[str, float], np.ndarray, Sequence[float]]
+ParamVecType = Union[Sequence[SingleParamVecType], SingleParamVecType]
 
 
 class EmulatorInput:

--- a/src/py21cmemu/output.py
+++ b/src/py21cmemu/output.py
@@ -1,55 +1,224 @@
 """Output class."""
+import dataclasses as dc
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Generator
+
+import numpy as np
+
+from .properties import emulator_properties
 
 
+@dataclass(frozen=True, kw_only=True)
 class EmulatorOutput:
-    r"""A class to easily use the emulator output.
+    """A simple class that makes it easier to access the corrected emulator output."""
 
-    Parameters
-    ----------
-    output : dict
-        A dict containing the outputs of the emulator.
-    """
+    Tb: np.ndarray
+    xHI: np.ndarray
+    Ts: np.ndarray
+    PS: np.ndarray
+    tau: np.ndarray
+    UVLFs: np.ndarray
 
-    def __init__(self, output: dict) -> None:
-        self.out_keys = [
-            "delta" "k",
-            "brightness_temp",
-            "spin_temp",
-            "tau_e",
-            "Muv",
-            "lfunc",
-            "uv_lfs_redshifts",
-            "ps_redshifts",
-            "redshifts",
-            "xHI",
-        ]
+    properties = emulator_properties
 
-        self.defining_dict = output
-        self.k = output["k"]
-        self.delta = output["delta"]
-        self.brightness_temp = output["brightness_temp"]
-        self.spin_temp = output["spin_temp"]
-        self.tau_e = output["tau_e"]
-        self.Muv = output["Muv"]
-        self.lfunc = output["lfunc"]
-        self.uv_lfs_redshifts = output["uv_lfs_redshifts"]
-        self.ps_redshifts = output["ps_redshifts"]
-        self.redshifts = output["redshifts"]
-        self.xHI = output["xHI"]
+    def keys(self) -> Generator[str, None, None]:
+        """Yield the keys of the main data products."""
+        for k in dc.fields(self):
+            yield k.name
 
-    def add_errors(self, errors: dict) -> None:
-        r"""Method to add the errors as attributes to the class.
+    def items(self) -> Generator[tuple[str, np.ndarray], None, None]:
+        """Yield the keys and values of the main data products, like a dict."""
+        for k in self.keys():
+            yield k, getattr(self, k)
+
+    def __getitem__(self, key: str) -> np.ndarray:
+        """Allow access to attributes as items."""
+        return getattr(self, key)
+
+    @property
+    def k(self) -> np.ndarray:
+        """The k-values of the power spectra."""
+        return self.properties.ks_cut
+
+    @property
+    def Muv(self) -> np.ndarray:
+        """The Muv-values of the UVLFs."""
+        return self.properties.UVLFs_MUVs
+
+    @property
+    def UVLF_redshifts(self) -> np.ndarray:
+        """The redshifts of the UVLFs."""
+        return self.properties.uv_lf_zs
+
+    @property
+    def ps_redshifts(self) -> np.ndarray:
+        """The redshifts of the power spectra."""
+        return self.properties.zs_cut
+
+    @property
+    def redshifts(self) -> np.ndarray:
+        """The redshifts of all quantities except the PS."""
+        return self.properties.zs
+
+    def squeeze(self):
+        """Return a new EmulatorOutput with all dimensions of length 1 removed."""
+        return EmulatorOutput(**{k: np.squeeze(v) for k, v in self.items()})
+
+    def write(
+        self,
+        fname: str | Path,
+        theta: np.ndarray | dict | None = None,
+        store: list[str] | None = None,
+        clobber: bool = False,
+    ):
+        """Write this instance's data to a file.
+
+        This saves the output as a numpy .npz file. The output is saved as a dictionary
+        with the keys being the names of the attributes of this class and the values
+        being the corresponding values of those attributes. If theta is not None, then
+        the inputs are also saved under the key "inputs".
 
         Parameters
         ----------
-        errors : dict
-            A dict containing the errors from the emulator.
-
+        fname : str or Path
+            The filename to write to.
+        theta : np.ndarray or dict or None, optional
+            The input parameters associated with this output data to write to the file.
+            If None, the inputs are not written.
+        store : list of str or None, optional
+            The names of the attributes to write to the file. If None, all attributes
+            are written.
+        clobber : bool, optional
+            Whether to overwrite the file if it already exists.
         """
-        for k in errors.keys():
-            self.defining_dict[k] = errors[k]
-        self.delta_err = errors["delta_err"]
-        self.brightness_temp_err = errors["brightness_temp_err"]
-        self.xHI_err = errors["xHI_err"]
-        self.spin_temp_err = errors["spin_temp_err"]
-        self.tau_e_err = errors["tau_e_err"]
+        if store is None:
+            store = list(self.__dict__.keys())
+
+        pth = Path(fname)
+        if pth.exists() and not clobber:
+            raise ValueError(f"File {pth} exists and clobber=False.")
+
+        out = {k: getattr(self, k) for k in store}
+
+        if theta is not None:
+            out["inputs"] = theta
+
+        np.savez(fname, out)
+
+
+@dataclass(frozen=True)
+class RawEmulatorOutput:
+    """A simple data-class that makes it easier to access the raw emulator output.
+
+    Parameters
+    ----------
+    output : np.ndarray
+        The raw output array from the emulator.
+    """
+
+    output: np.ndarray
+
+    properties = emulator_properties
+
+    @property
+    def nz(self) -> int:
+        """Number of redshifts in the output."""
+        return np.array(self.properties.zs).shape[0]
+
+    @property
+    def nparams(self) -> int:
+        """Number of sets of parameters in the output."""
+        return self.output.shape[0]
+
+    @property
+    def Tb(self) -> np.ndarray:
+        """Mean 21cm brightness temperature in mK as a function of redshift."""
+        return self.output[:, : self.nz]
+
+    @property
+    def xHI(self) -> np.ndarray:
+        """Neutral fraction as a function of redshift."""
+        return self.output[:, self.nz : 2 * self.nz]
+
+    @property
+    def Ts(self) -> np.ndarray:
+        """Mean spin temperature in K as a function of redshift."""
+        return self.output[:, 2 * self.nz : 3 * self.nz]
+
+    @property
+    def reshift_where_Ts_becomes_defined(self) -> np.ndarray:
+        """The redshift at which the spin temperature becomes well-defined."""
+        return self.output[:, 3 * self.nz]
+
+    @property
+    def PS(self) -> np.ndarray:
+        """The power spectrum in mK^2 as a function of redshift and k."""
+        return self.output[:, 3 * self.nz + 1 : 3 * self.nz + 1 + 60 * 12].reshape(
+            (-1, 60, 12)
+        )
+
+    @property
+    def tau(self) -> np.ndarray:
+        """The optical depth of reionization."""
+        return self.output[:, self.nz * 3 + 1 + 60 * 12]
+
+    @property
+    def UVLFs(self) -> np.ndarray:
+        """The UV luminosity functions as a function of z and Muv."""
+        return self.output[:, self.nz * 3 + 1 + 60 * 12 + 1 :].reshape(
+            (-1, len(self.properties.uv_lf_zs), len(self.properties.UVLFs_MUVs))
+        )
+
+    def renormalize(self, name: str):
+        """Renormalize a normalized quantity.
+
+        This ajudsts the quantity (as it exists in this class) back to its native
+        range by adding the emulator data mean and multiplying by the emulator data
+        standard deviation.
+        """
+        if name not in self.properties.normalized_quantities:
+            raise ValueError(
+                f"Cannot renormalize {name}. It is not a normalized quantity."
+            )
+        return getattr(self.properties, f"{name}_mean") + getattr(
+            self.properties, f"{name}_std"
+        ) * getattr(self, name)
+
+    def get_renormalized(self) -> EmulatorOutput:
+        """Get the output with normalized quantities re-normalized.
+
+        Returns
+        -------
+        EmulatorOutput
+            The emulator output with normalized quantities re-normalized back to
+            physical units.
+        """
+        # Restore dimensions
+        # Renormalize stuff that needs renormalization
+        renorm = {k: self.renormalize(k) for k in self.properties.normalized_quantities}
+
+        other = {
+            k.name: getattr(self, k.name)
+            for k in dc.fields(EmulatorOutput)
+            if k.name not in renorm
+        }
+
+        out = renorm | other
+
+        # Set the xHI < z(Ts undefined) to 0
+        # For Ts, set it to NaN
+        for i in range(self.nparams):
+            zbin = np.argmin(
+                abs(self.properties.zs - self.reshift_where_Ts_becomes_defined[i])
+            )
+            if out["xHI"][i, zbin] < 1e-1:
+                out["xHI"][i, :zbin] = 0.0
+            out["Ts"][i, :zbin] = np.nan
+
+        # Undo log10 on some quantities
+        out["PS"] = 10 ** out["PS"]
+        out["Ts"] = 10 ** out["Ts"]
+        out["tau"] = 10 ** out["tau"]
+
+        return EmulatorOutput(**out).squeeze()

--- a/src/py21cmemu/output.py
+++ b/src/py21cmemu/output.py
@@ -206,7 +206,7 @@ class RawEmulatorOutput:
             if k.name not in renorm
         }
 
-        out = renorm | other
+        out = {**renorm, **other}
 
         # Set the xHI < z(Ts undefined) to 0
         # For Ts, set it to NaN

--- a/src/py21cmemu/output.py
+++ b/src/py21cmemu/output.py
@@ -11,7 +11,7 @@ import numpy as np
 from .properties import emulator_properties
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(frozen=True)
 class EmulatorOutput:
     """A simple class that makes it easier to access the corrected emulator output."""
 

--- a/src/py21cmemu/output.py
+++ b/src/py21cmemu/output.py
@@ -1,4 +1,6 @@
 """Output class."""
+from __future__ import annotations
+
 import dataclasses as dc
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/py21cmemu/properties.py
+++ b/src/py21cmemu/properties.py
@@ -1,0 +1,88 @@
+"""A module definining the static properties of the Emulator."""
+from pathlib import Path
+
+import numpy as np
+
+
+USER_PARAMS = {
+    "BOX_LEN": 250,
+    "DIM": 512,
+    "HII_DIM": 128,
+    "USE_FFTW_WISDOM": True,
+    "HMF": 1,
+    "USE_RELATIVE_VELOCITIES": False,
+    "POWER_SPECTRUM": 0,
+    "N_THREADS": 1,
+    "PERTURB_ON_HIGH_RES": False,
+    "NO_RNG": False,
+    "USE_INTERPOLATION_TABLES": True,
+    "FAST_FCOLL_TABLES": False,
+    "USE_2LPT": True,
+    "MINIMIZE_MEMORY": False,
+}
+
+COSMO_PARAMS = {
+    "SIGMA_8": 0.82,
+    "hlittle": 0.6774,
+    "OMm": 0.3075,
+    "OMb": 0.0486,
+    "POWER_INDEX": 0.97,
+}
+
+FLAG_OPTIONS = {
+    "USE_HALO_FIELD": False,
+    "USE_MINI_HALOS": False,
+    "USE_MASS_DEPENDENT_ZETA": True,
+    "SUBCELL_RSD": True,
+    "INHOMO_RECO": True,
+    "USE_TS_FLUCT": True,
+    "M_MIN_in_Mass": False,
+    "PHOTON_CONS": True,
+    "FIX_VCB_AVG": False,
+}
+
+
+class EmulatorProperties:
+    """A class that contains the properties of the emulator."""
+
+    def __init__(self):
+        here = Path(__file__).parent
+        all_emulator_numbers = np.load(here / "emulator_constants.npz")
+        self._data = all_emulator_numbers
+
+        self.zs = all_emulator_numbers["zs"]
+        self.limits = all_emulator_numbers["limits"]
+        self.zs_cut = self.zs[:60]
+        self.ks_cut = all_emulator_numbers["ks"][1:-3]
+        self.PS_mean = all_emulator_numbers["PS_mean"]
+        self.PS_std = all_emulator_numbers["PS_std"]
+        self.Tb_mean = all_emulator_numbers["Tb_mean"]
+        self.Tb_std = all_emulator_numbers["Tb_std"]
+        self.Ts_mean = all_emulator_numbers["Ts_mean"]
+        self.Ts_std = all_emulator_numbers["Ts_std"]
+
+        self.tau_mean = all_emulator_numbers["tau_mean"]
+        self.tau_std = all_emulator_numbers["tau_std"]
+
+        self.UVLFs_mean = all_emulator_numbers["UVLFs_mean"]
+        self.UVLFs_std = all_emulator_numbers["UVLFs_std"]
+        self.UVLFs_MUVs = np.append(np.arange(-25, -15, 1.0), np.arange(-15, -4.5, 0.5))
+        self.uv_lf_zs = np.array([6, 7, 8, 10])
+
+        self.PS_err = all_emulator_numbers["PS_err"]
+        self.Tb_err = all_emulator_numbers["Tb_err"]
+        self.Ts_err = all_emulator_numbers["Ts_err"]
+        self.xHI_err = all_emulator_numbers["xHI_err"]
+        self.tau_err = all_emulator_numbers["tau_err"]
+
+        self.flag_options = FLAG_OPTIONS
+        self.user_params = USER_PARAMS
+        self.cosmo_params = COSMO_PARAMS
+
+    @property
+    def normalized_quantities(self) -> list[str]:
+        """Return a list of the normalized quantities predicted by the emulator."""
+        return [k.split("_")[0] for k in self._data if k.endswith("_mean")]
+
+
+emulator_properties = EmulatorProperties()

--- a/src/py21cmemu/properties.py
+++ b/src/py21cmemu/properties.py
@@ -1,4 +1,6 @@
 """A module definining the static properties of the Emulator."""
+from __future__ import annotations
+
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
This PR significantly refactors the way that the Emulator is used, to make it a bit more granular. There is now an `inputs.py` module to deal with formatting the input parameters, a `properties.py` module which deals with the static properties of the emulator (essentially reading the `emulator_constants.npz` file), and an `outputs.py` module which wraps up the outputs of the emulator more nicely. 

I have also taken out the automatic writing inside the `predict()` method, because of the single-responsibility principle, i.e. the `predict()` method should only predict, not write. The logic for writing files is now included as a new standalone method in the `EmulatorOutput` class. It doesn't try to create a new filename based on the params automatically, but rather lets the user decide that. I would say the best place to do this is actually within the 21cmMC wrapper script. 

Also, I renamed `format_theta` into `make_params_array`, and now it ONLY returns the array (not the dict), either normalized or not based on an input parameter. There's a different method for instead creating a list of dicts. Again, since this list of dicts was used in auto-computing the filename, we can just call that method from the 21cmMC wrapper.